### PR TITLE
Button Registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ Once the plugin has been loaded and registered, add it to your Video.js player u
 Video.js' plugin configuration option (see "[Setting up a Plugin][videojs-plugin-setup]"
 on the Video.js docs). Use these options to configure the plugin:
 
+   * **`plugins.remotePlayback.addButtonToControlBar`**: A `boolean` that will use
+     determine whether the button is added to the Video.js control bar.
+     Default: `true`.
    * **`plugins.remotePlayback.preferNativeAirPlay`**: A `boolean` that will use native
      AirPlay APIs when AirPlay is available, instead of Remote Playback API.
      Default: `false`.

--- a/src/js/RemotePlaybackPlugin.ts
+++ b/src/js/RemotePlaybackPlugin.ts
@@ -30,8 +30,10 @@ export function isPlayerWithRemotePlaybackPlugin(o: unknown): o is VideoJsPlayer
       'currentTime' in o && typeof o.currentTime === 'function' &&
       'play' in o && typeof o.play === 'function' &&
       'pause' in o && typeof o.pause === 'function' &&
+      // Use `hasPlugin` so type guard works if plugin isn't initialized yet
+      'hasPlugin' in o && typeof o.hasPlugin === 'function' &&
       // Finally, check for presence of our plugin
-      'remotePlayback' in o && typeof o.remotePlayback === 'function';
+      o.hasPlugin('remotePlayback') && 'remotePlayback' in o && typeof o.remotePlayback === 'function';
 }
 
 // DEFAULTS / CONSTANTS

--- a/src/js/RemotePlaybackPlugin.ts
+++ b/src/js/RemotePlaybackPlugin.ts
@@ -1,4 +1,3 @@
-import type { Button } from '@silvermine/video.js';
 import type { BaseButtonOptions } from './buttons/BaseButton';
 import type { VideoJsPlayer } from '../../@types/videojs';
 import videojs from '@silvermine/video.js';
@@ -12,7 +11,6 @@ import { checkClientSupportWithAirPlay, checkClientSupport } from './lib/check-c
 export interface RemotePlaybackStrategy {
    kind: 'AirPlay' | 'RemotePlaybackAPI';
    dispose(): void;
-   makeButton(options: Partial<BaseButtonOptions>): Button | undefined;
    prompt(): Promise<void>;
    get player(): VideoJsPlayer;
 }
@@ -45,6 +43,7 @@ const defaultOptions: RemotePlaybackPluginOptions = {
 };
 
 export const COMPONENT_NAMES = {
+   REMOTE_PLAYBACK_BUTTON: 'remotePlaybackButton',
    CONTROL_BAR: 'controlBar',
    FULLSCREEN_TOGGLE: 'fullscreenToggle',
 } as const;
@@ -120,17 +119,12 @@ export class RemotePlaybackPlugin extends Plugin {
          const fullscreenToggle = controlBar.getChild(COMPONENT_NAMES.FULLSCREEN_TOGGLE),
                children = controlBar.children(),
                fullscreenToggleIndex = fullscreenToggle ? children.indexOf(fullscreenToggle) : -1,
-               insertIndex = fullscreenToggleIndex >= 0 ? fullscreenToggleIndex : children.length,
-               button = this.strategy?.makeButton(this._options);
+               insertIndex = fullscreenToggleIndex >= 0 ? fullscreenToggleIndex : children.length;
 
-         if (button) {
-            controlBar.addChild(button, {}, insertIndex);
-            this.log(`Added ${this.strategy?.kind} manager button to control bar at index ${insertIndex}.`);
-         } else {
-            this.log.error(`Failed to create ${this.strategy?.kind} button.`);
-         }
+         controlBar.addChild(COMPONENT_NAMES.REMOTE_PLAYBACK_BUTTON, this._options, insertIndex);
+         this.log(`Added ${this.strategy?.kind} ${COMPONENT_NAMES.REMOTE_PLAYBACK_BUTTON} to control bar at index ${insertIndex}.`);
       } catch(error) {
-         this.log.error(`Failed to add ${this.strategy?.kind} manager button to control bar,`, error);
+         this.log.error(`Failed to add ${this.strategy?.kind} ${COMPONENT_NAMES.REMOTE_PLAYBACK_BUTTON} to control bar,`, error);
       }
    }
 }

--- a/src/js/RemotePlaybackPlugin.ts
+++ b/src/js/RemotePlaybackPlugin.ts
@@ -51,7 +51,6 @@ const Plugin = videojs.getPlugin('plugin');
 
 export class RemotePlaybackPlugin extends Plugin {
    public readonly log!: videojs.Log;
-   private readonly _player: VideoJsPlayer;
    private readonly _options: RemotePlaybackPluginOptions;
    private _strategy: RemotePlaybackStrategy | undefined;
    private readonly _listeners = {
@@ -69,21 +68,21 @@ export class RemotePlaybackPlugin extends Plugin {
 
    public constructor(player: videojs.Player, options: Partial<RemotePlaybackPluginOptions> = {}) {
       super(player, options);
-      // The constructor receives a standard Video.js Player, but then we assert the type
-      // of our custom VideoJsPlayer. This is safe because the plugin has been registered
-      // at this point.
-      this._player = player as VideoJsPlayer;
       this._options = Object.assign({}, defaultOptions, options);
       Object.entries(this._listeners).forEach(([ event, listener ]) => {
-         this._player.on(event, listener);
+         this.player.on(event, listener);
       });
-      this._player.ready(() => {
+      this.player.ready(() => {
+         if (!isPlayerWithRemotePlaybackPlugin(this.player)) {
+            this.log.error('Player is missing the plugin!');
+            return;
+         }
          if (this._options.preferNativeAirPlay && checkClientSupportWithAirPlay()) {
             this.log('Initializing with native AirPlay strategy.');
-            this._strategy = new AirPlayManager(this._player);
+            this._strategy = new AirPlayManager(this.player);
          } else if (checkClientSupport()) {
             this.log('Initializing with Remote Playback API strategy.');
-            this._strategy = new RemotePlaybackManager(this._player);
+            this._strategy = new RemotePlaybackManager(this.player);
          } else {
             this.log.error('No supported strategies available!');
             return;
@@ -95,7 +94,7 @@ export class RemotePlaybackPlugin extends Plugin {
    public dispose(): void {
       this.log(`Disposing of ${this.strategy?.kind} strategy.`);
       Object.entries(this._listeners).forEach(([ event, listener ]) => {
-         this._player.off(event, listener);
+         this.player.off(event, listener);
       });
       this.strategy?.dispose();
       super.dispose();
@@ -106,7 +105,7 @@ export class RemotePlaybackPlugin extends Plugin {
    }
 
    private _addButtonToControlBar(): void {
-      const controlBar = this._player.getChild(COMPONENT_NAMES.CONTROL_BAR);
+      const controlBar = this.player.getChild(COMPONENT_NAMES.CONTROL_BAR);
 
       if (!controlBar) {
          this.log.error(`Control bar component not found. Cannot add ${this.strategy?.kind} manager button.`);

--- a/src/js/RemotePlaybackPlugin.ts
+++ b/src/js/RemotePlaybackPlugin.ts
@@ -18,6 +18,7 @@ export interface RemotePlaybackStrategy {
 }
 
 export interface RemotePlaybackPluginOptions extends Partial<BaseButtonOptions> {
+   addButtonToControlBar: boolean;
    preferNativeAirPlay: boolean;
 }
 
@@ -39,6 +40,7 @@ export function isPlayerWithRemotePlaybackPlugin(o: unknown): o is VideoJsPlayer
 // DEFAULTS / CONSTANTS
 
 const defaultOptions: RemotePlaybackPluginOptions = {
+   addButtonToControlBar: true,
    preferNativeAirPlay: false,
 };
 
@@ -87,7 +89,9 @@ export class RemotePlaybackPlugin extends Plugin {
             this.log.error('No supported strategies available!');
             return;
          }
-         this._addButtonToControlBar();
+         if (this._options.addButtonToControlBar) {
+            this._addButtonToControlBar();
+         }
       });
    }
 

--- a/src/js/RemotePlaybackPlugin.ts
+++ b/src/js/RemotePlaybackPlugin.ts
@@ -2,6 +2,7 @@ import type { Button } from '@silvermine/video.js';
 import type { BaseButtonOptions } from './buttons/BaseButton';
 import type { VideoJsPlayer } from '../../@types/videojs';
 import videojs from '@silvermine/video.js';
+import EVENTS from './constants/events';
 import { AirPlayManager } from './strategies/AirPlayManager';
 import { RemotePlaybackManager } from './strategies/RemotePlaybackManager';
 import { checkClientSupportWithAirPlay, checkClientSupport } from './lib/check-client-support';
@@ -51,6 +52,18 @@ export class RemotePlaybackPlugin extends Plugin {
    private readonly _player: VideoJsPlayer;
    private readonly _options: RemotePlaybackPluginOptions;
    private _strategy: RemotePlaybackStrategy | undefined;
+   private readonly _listeners = {
+      [EVENTS.PROMPT_REQUESTED]: () => {
+         if (!this._strategy) {
+            this.log.error('No remote playback strategy available to handle prompt intent!');
+            return;
+         }
+
+         this._strategy.prompt().catch((error: Error) => {
+            this.log.error(error);
+         });
+      },
+   };
 
    public constructor(player: videojs.Player, options: Partial<RemotePlaybackPluginOptions> = {}) {
       super(player, options);
@@ -59,6 +72,9 @@ export class RemotePlaybackPlugin extends Plugin {
       // at this point.
       this._player = player as VideoJsPlayer;
       this._options = Object.assign({}, defaultOptions, options);
+      Object.entries(this._listeners).forEach(([ event, listener ]) => {
+         this._player.on(event, listener);
+      });
       this._player.ready(() => {
          if (this._options.preferNativeAirPlay && checkClientSupportWithAirPlay()) {
             this.log('Initializing with native AirPlay strategy.');
@@ -76,6 +92,9 @@ export class RemotePlaybackPlugin extends Plugin {
 
    public dispose(): void {
       this.log(`Disposing of ${this.strategy?.kind} strategy.`);
+      Object.entries(this._listeners).forEach(([ event, listener ]) => {
+         this._player.off(event, listener);
+      });
       this.strategy?.dispose();
       super.dispose();
    }

--- a/src/js/buttons/AirPlayButton.ts
+++ b/src/js/buttons/AirPlayButton.ts
@@ -1,4 +1,4 @@
-import type { RemotePlaybackStrategy } from '../RemotePlaybackPlugin';
+import type { VideoJsPlayer } from '../../../@types/videojs';
 import { BaseButton, BaseButtonOptions } from './BaseButton';
 
 // DEFAULTS
@@ -10,8 +10,8 @@ export const defaultAirPlayButtonOptions: BaseButtonOptions = {
 
 export class AirPlayButton extends BaseButton {
 
-   public constructor(manager: RemotePlaybackStrategy, options: Partial<BaseButtonOptions> = {}) {
-      super(manager, Object.assign({}, defaultAirPlayButtonOptions, options));
+   public constructor(player: VideoJsPlayer, options: Partial<BaseButtonOptions> = {}) {
+      super(player, Object.assign({}, defaultAirPlayButtonOptions, options));
    }
 
    public buildCSSClass(): string {

--- a/src/js/buttons/BaseButton.ts
+++ b/src/js/buttons/BaseButton.ts
@@ -51,23 +51,22 @@ export class BaseButton extends Button {
          this.hide();
       },
    };
-   private readonly _options: BaseButtonOptions;
 
    public constructor(player: VideoJsPlayer, options: Partial<BaseButtonOptions> = {}) {
+      const { addLabelToButton, label } = Object.assign({}, defaultButtonOptions, options);
+
       super(player, options);
 
-      this._options = Object.assign({}, defaultButtonOptions, options);
-
       // Add label if configured to do so
-      if (this._options.addLabelToButton) {
+      if (addLabelToButton) {
          const labelEl = document.createElement('span');
 
          labelEl.classList.add(CSS_CLASSES.BUTTON_LABEL);
-         labelEl.textContent = this._options.label;
+         labelEl.textContent = label;
          this.el().appendChild(labelEl);
          this.el().classList.add(CSS_CLASSES.BUTTON_LARGE);
       } else {
-         this.controlText(this._options.label);
+         this.controlText(label);
       }
 
       // Add event listeners

--- a/src/js/buttons/BaseButton.ts
+++ b/src/js/buttons/BaseButton.ts
@@ -62,7 +62,7 @@ export class BaseButton extends Button {
          const labelEl = document.createElement('span');
 
          labelEl.classList.add(CSS_CLASSES.BUTTON_LABEL);
-         labelEl.textContent = label;
+         labelEl.textContent = this.localize(label);
          this.el().appendChild(labelEl);
          this.el().classList.add(CSS_CLASSES.BUTTON_LARGE);
       } else {

--- a/src/js/buttons/BaseButton.ts
+++ b/src/js/buttons/BaseButton.ts
@@ -53,7 +53,6 @@ export class BaseButton extends Button {
    };
    private readonly _options: BaseButtonOptions;
    private readonly _player: VideoJsPlayer;
-   private _labelEl?: HTMLSpanElement;
 
    public constructor(player: VideoJsPlayer, options: Partial<BaseButtonOptions> = {}) {
       super(player, options);
@@ -63,13 +62,12 @@ export class BaseButton extends Button {
 
       // Add label if configured to do so
       if (this._options.addLabelToButton) {
+         const labelEl = document.createElement('span');
+
+         labelEl.classList.add(CSS_CLASSES.BUTTON_LABEL);
+         labelEl.textContent = this._options.label;
+         this.el().appendChild(labelEl);
          this.el().classList.add(CSS_CLASSES.BUTTON_LARGE);
-
-         this._labelEl = document.createElement('span');
-         this._labelEl.classList.add(CSS_CLASSES.BUTTON_LABEL);
-         this._labelEl.textContent = this._options.label;
-
-         this.el().appendChild(this._labelEl);
       } else {
          this.controlText(this._options.label);
       }

--- a/src/js/buttons/BaseButton.ts
+++ b/src/js/buttons/BaseButton.ts
@@ -52,13 +52,11 @@ export class BaseButton extends Button {
       },
    };
    private readonly _options: BaseButtonOptions;
-   private readonly _player: VideoJsPlayer;
 
    public constructor(player: VideoJsPlayer, options: Partial<BaseButtonOptions> = {}) {
       super(player, options);
 
       this._options = Object.assign({}, defaultButtonOptions, options);
-      this._player = player;
 
       // Add label if configured to do so
       if (this._options.addLabelToButton) {
@@ -74,7 +72,7 @@ export class BaseButton extends Button {
 
       // Add event listeners
       Object.entries(this._listeners).forEach(([ event, listener ]) => {
-         this._player.on(event, listener);
+         this.player().on(event, listener);
       });
    }
 
@@ -83,12 +81,12 @@ export class BaseButton extends Button {
    }
 
    public handleClick(): void {
-      this._player.trigger(EVENTS.PROMPT_REQUESTED);
+      this.player().trigger(EVENTS.PROMPT_REQUESTED);
    }
 
    public dispose(): void {
       Object.entries(this._listeners).forEach(([ event, listener ]) => {
-         this._player.off(event, listener);
+         this.player().off(event, listener);
       });
       super.dispose();
    }

--- a/src/js/buttons/BaseButton.ts
+++ b/src/js/buttons/BaseButton.ts
@@ -2,7 +2,6 @@ import videojs from '@silvermine/video.js';
 import type { ComponentOptions } from '@silvermine/video.js';
 import type { VideoJsPlayer } from '../../../@types/videojs';
 import EVENTS from '../constants/events';
-import type { RemotePlaybackPlugin, RemotePlaybackStrategy } from '../RemotePlaybackPlugin';
 
 // INTERFACES
 
@@ -54,15 +53,13 @@ export class BaseButton extends Button {
    };
    private readonly _options: BaseButtonOptions;
    private readonly _player: VideoJsPlayer;
-   private readonly _manager: RemotePlaybackStrategy;
    private _labelEl?: HTMLSpanElement;
 
-   public constructor(manager: RemotePlaybackStrategy, options: Partial<BaseButtonOptions> = {}) {
-      super(manager.player, options);
+   public constructor(player: VideoJsPlayer, options: Partial<BaseButtonOptions> = {}) {
+      super(player, options);
 
       this._options = Object.assign({}, defaultButtonOptions, options);
-      this._manager = manager;
-      this._player = manager.player;
+      this._player = player;
 
       // Add label if configured to do so
       if (this._options.addLabelToButton) {
@@ -88,13 +85,7 @@ export class BaseButton extends Button {
    }
 
    public handleClick(): void {
-      if (!this._manager) {
-         this.plugin?.log.error('Manager not available');
-         return;
-      }
-      this._manager.prompt().catch((error: Error) => {
-         this.plugin?.log.error(error);
-      });
+      this._player.trigger(EVENTS.PROMPT_REQUESTED);
    }
 
    public dispose(): void {
@@ -102,10 +93,6 @@ export class BaseButton extends Button {
          this._player.off(event, listener);
       });
       super.dispose();
-   }
-
-   private get plugin(): RemotePlaybackPlugin | undefined {
-      return this._player.usingPlugin('remotePlayback') ? this._player.remotePlayback() : undefined;
    }
 
 }

--- a/src/js/constants/events.ts
+++ b/src/js/constants/events.ts
@@ -6,4 +6,6 @@ export default {
    CONNECTING: 'remoteplayback:connecting',
    CONNECTED: 'remoteplayback:connected',
    DISCONNECTED: 'remoteplayback:disconnected',
+   // Intents
+   PROMPT_REQUESTED: 'remoteplayback:prompt',
 } as const;

--- a/src/js/index.ts
+++ b/src/js/index.ts
@@ -1,9 +1,13 @@
 import type { VideoJs } from '../../@types/videojs';
-import { RemotePlaybackPlugin } from './RemotePlaybackPlugin';
+import { COMPONENT_NAMES, RemotePlaybackPlugin } from './RemotePlaybackPlugin';
 import '../styles/index.scss';
+import { AirPlayButton } from './buttons/AirPlayButton';
+import { BaseButton } from './buttons/BaseButton';
+import { checkClientSupportWithAirPlay } from './lib/check-client-support';
 
 // Receives a video.js instance and registers the plugin
 export default function initializePlugin(videojs: VideoJs): void {
+   videojs.registerComponent(COMPONENT_NAMES.REMOTE_PLAYBACK_BUTTON, checkClientSupportWithAirPlay() ? AirPlayButton : BaseButton);
    videojs.registerPlugin('remotePlayback', RemotePlaybackPlugin);
    videojs.log(`Remote Playback plugin registered with video.js version ${videojs.VERSION}.`);
 }

--- a/src/js/strategies/AirPlayManager.ts
+++ b/src/js/strategies/AirPlayManager.ts
@@ -1,11 +1,8 @@
 import type { VideoJsPlayer } from '../../../@types/videojs';
-import { Button } from '@silvermine/video.js';
 import EVENTS from '../constants/events';
 import type { RemotePlaybackPlugin, RemotePlaybackStrategy } from '../RemotePlaybackPlugin';
-import { BaseButtonOptions } from '../buttons/BaseButton';
 import { getVideoElementWithAirPlay, HTMLVideoElementWithAirPlay } from '../lib/get-video-element';
 import { checkClientSupportWithAirPlay } from '../lib/check-client-support';
-import { AirPlayButton } from '../buttons/AirPlayButton';
 
 interface RemotePlaybackAvailabilityEvent extends Event {
    availability: 'available' | 'not-available';
@@ -71,12 +68,6 @@ export class AirPlayManager implements RemotePlaybackStrategy {
 
    public get player(): VideoJsPlayer {
       return this._player;
-   }
-
-   public makeButton(options: Partial<BaseButtonOptions> = {}): Button | undefined {
-      if (checkClientSupportWithAirPlay()) {
-         return new AirPlayButton(this._player, options);
-      }
    }
 
    /**

--- a/src/js/strategies/AirPlayManager.ts
+++ b/src/js/strategies/AirPlayManager.ts
@@ -75,7 +75,7 @@ export class AirPlayManager implements RemotePlaybackStrategy {
 
    public makeButton(options: Partial<BaseButtonOptions> = {}): Button | undefined {
       if (checkClientSupportWithAirPlay()) {
-         return new AirPlayButton(this, options);
+         return new AirPlayButton(this._player, options);
       }
    }
 

--- a/src/js/strategies/RemotePlaybackManager.ts
+++ b/src/js/strategies/RemotePlaybackManager.ts
@@ -1,11 +1,8 @@
 import type { VideoJsPlayer } from '../../../@types/videojs';
-import { Button } from '@silvermine/video.js';
 import EVENTS from '../constants/events';
 import { RemotePlaybackPlugin, RemotePlaybackStrategy } from '../RemotePlaybackPlugin';
-import { BaseButton, BaseButtonOptions } from '../buttons/BaseButton';
-import { AirPlayButton } from '../buttons/AirPlayButton';
 import { getVideoElement } from '../lib/get-video-element';
-import { checkClientSupport, checkClientSupportWithAirPlay } from '../lib/check-client-support';
+import { checkClientSupport } from '../lib/check-client-support';
 
 /**
  * Orchestrates remote playback behavior for a single Video.js player.
@@ -46,16 +43,6 @@ export class RemotePlaybackManager implements RemotePlaybackStrategy {
 
    public get player(): VideoJsPlayer {
       return this._player;
-   }
-
-   public makeButton(options: Partial<BaseButtonOptions> = {}): Button | undefined {
-      if (checkClientSupportWithAirPlay()) {
-         // If AirPlay is available, we use that detection to use an AirPlay button just
-         // to provide a different icon/label appearance.
-         return new AirPlayButton(this._player, options);
-      } else if (checkClientSupport()) {
-         return new BaseButton(this._player, options);
-      }
    }
 
    /**

--- a/src/js/strategies/RemotePlaybackManager.ts
+++ b/src/js/strategies/RemotePlaybackManager.ts
@@ -52,9 +52,9 @@ export class RemotePlaybackManager implements RemotePlaybackStrategy {
       if (checkClientSupportWithAirPlay()) {
          // If AirPlay is available, we use that detection to use an AirPlay button just
          // to provide a different icon/label appearance.
-         return new AirPlayButton(this, options);
+         return new AirPlayButton(this._player, options);
       } else if (checkClientSupport()) {
-         return new BaseButton(this, options);
+         return new BaseButton(this._player, options);
       }
    }
 

--- a/tests/buttons.test.ts
+++ b/tests/buttons.test.ts
@@ -5,17 +5,16 @@ import type { VideoJsPlayer } from '../@types/videojs';
 import EVENTS from '../src/js/constants/events';
 import { BaseButton } from '../src/js/buttons/BaseButton';
 import { AirPlayButton } from '../src/js/buttons/AirPlayButton';
-import { RemotePlaybackStrategy } from '../src/js/RemotePlaybackPlugin';
 
 interface ListenerMap {
    [event: string]: () => void;
 }
 
 interface TestContext {
-   manager: RemotePlaybackStrategy;
    player: VideoJsPlayer & {
       on: ReturnType<typeof vi.fn>;
       off: ReturnType<typeof vi.fn>;
+      trigger: ReturnType<typeof vi.fn>;
       usingPlugin: ReturnType<typeof vi.fn>;
       remotePlayback: ReturnType<typeof vi.fn>;
    };
@@ -28,6 +27,7 @@ function createContext(): TestContext {
          pluginError = vi.fn(),
          on = vi.fn((event: string, listener: () => void) => { listeners[event] = listener; }),
          off = vi.fn(),
+         trigger = vi.fn(),
          usingPlugin = vi.fn().mockReturnValue(true),
          remotePlayback = vi.fn().mockReturnValue({ log: { error: pluginError } });
 
@@ -36,18 +36,10 @@ function createContext(): TestContext {
       off,
       usingPlugin,
       remotePlayback,
+      trigger,
    } as TestContext['player'];
 
-   const manager: RemotePlaybackStrategy = {
-      dispose: vi.fn(),
-      kind: 'RemotePlaybackAPI',
-      makeButton: (options) => { return new BaseButton(manager, options); },
-      player,
-      prompt: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
-   };
-
    return {
-      manager,
       player,
       listeners,
       pluginError,
@@ -60,8 +52,8 @@ describe('BaseButton', () => {
    });
 
    it('registers listeners and appends a label by default', () => {
-      const { manager, player } = createContext(),
-            button = new BaseButton(manager, { label: 'AirPlay' }),
+      const { player } = createContext(),
+            button = new BaseButton(player, { label: 'AirPlay' }),
             label = button.el().querySelector('.vjs-remoteplayback-button-label');
 
       expect(player.on).toHaveBeenCalledTimes(5);
@@ -76,16 +68,16 @@ describe('BaseButton', () => {
    });
 
    it('uses controlText when label rendering is disabled', () => {
-      const { manager } = createContext(),
-            button = new BaseButton(manager, { addLabelToButton: false, label: 'Cast' });
+      const { player } = createContext(),
+            button = new BaseButton(player, { addLabelToButton: false, label: 'Cast' });
 
       expect((button as unknown as MockButton)._controlText).toBe('Cast');
       expect(button.el().querySelector('.vjs-remoteplayback-button-label')).toBeNull();
    });
 
    it('reacts to player events with expected class and visibility changes', () => {
-      const { manager, listeners } = createContext(),
-            button = new BaseButton(manager);
+      const { player, listeners } = createContext(),
+            button = new BaseButton(player);
 
       const showSpy = vi.spyOn(button, 'show'),
             hideSpy = vi.spyOn(button, 'hide');
@@ -110,25 +102,25 @@ describe('BaseButton', () => {
    });
 
    it('buildCSSClass prepends the component class', () => {
-      const { manager } = createContext(),
-            button = new BaseButton(manager),
+      const { player } = createContext(),
+            button = new BaseButton(player),
             classes = button.buildCSSClass();
 
       expect(classes).toContain('vjs-remoteplayback-button');
       expect(classes).toContain('vjs-control');
    });
 
-   it('handleClick prompts the manager when available', () => {
-      const { manager } = createContext(),
-            button = new BaseButton(manager);
+   it('handleClick emits a remote playback intent', () => {
+      const { player } = createContext(),
+            button = new BaseButton(player);
 
       button.handleClick();
-      expect(manager.prompt).toHaveBeenCalledTimes(1);
+      expect(player.trigger).toHaveBeenCalledTimes(1);
    });
 
    it('dispose removes all listeners and calls super.dispose', () => {
-      const { manager, player, listeners } = createContext(),
-            button = new BaseButton(manager);
+      const { player, listeners } = createContext(),
+            button = new BaseButton(player);
 
       button.dispose();
 
@@ -148,8 +140,8 @@ describe('AirPlayButton', () => {
    });
 
    it('uses AirPlay defaults and prepends its CSS class', () => {
-      const { manager } = createContext(),
-            button = new AirPlayButton(manager),
+      const { player } = createContext(),
+            button = new AirPlayButton(player),
             label = button.el().querySelector('.vjs-remoteplayback-button-label'),
             classes = button.buildCSSClass();
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,9 +1,27 @@
-import { describe, it, expect } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import './mocks/video-js-mock';
 import videojs from '@silvermine/video.js';
 import initializePlugin from '../src/js';
+import { RemotePlaybackPlugin } from '../src/js/RemotePlaybackPlugin';
+import EVENTS from '../src/js/constants/events';
+import { BaseButton } from '../src/js/buttons/BaseButton';
+import { checkClientSupport, checkClientSupportWithAirPlay } from '../src/js/lib/check-client-support';
+import { VideoJsPlayer } from '../@types/videojs';
+
+vi.mock('../src/js/lib/check-client-support', () => {
+   return {
+      checkClientSupport: vi.fn(),
+      checkClientSupportWithAirPlay: vi.fn(),
+   };
+});
 
 describe('Remote Playback Plugin', () => {
+   beforeEach(() => {
+      vi.clearAllMocks();
+      vi.mocked(checkClientSupport).mockReturnValue(true);
+      vi.mocked(checkClientSupportWithAirPlay).mockReturnValue(false);
+   });
+
    it('should initialize plugin without errors', () => {
       const initFunction = (): void => {
          initializePlugin(videojs);
@@ -11,5 +29,64 @@ describe('Remote Playback Plugin', () => {
 
       expect(initFunction).not.toThrow();
       expect(videojs.registerPlugin).toHaveBeenCalled();
+   });
+
+   it('routes prompt intent to the active strategy', async () => {
+      const listeners: Record<string, () => void> = {};
+
+      const videoElement = document.createElement('video');
+
+      Object.defineProperty(videoElement, 'remote', {
+         writable: true,
+         value: {
+            addEventListener: vi.fn(),
+            cancelWatchAvailability: vi.fn().mockResolvedValue(undefined),
+            prompt: vi.fn().mockResolvedValue(undefined),
+            removeEventListener: vi.fn(),
+            watchAvailability: vi.fn().mockResolvedValue(1),
+         } as unknown as RemotePlayback,
+      });
+
+      let plugin: RemotePlaybackPlugin;
+
+      const player = {
+         currentTime: vi.fn(),
+         el: vi.fn().mockReturnValue({
+            querySelector: vi.fn().mockReturnValue(videoElement),
+         }),
+         hasPlugin: vi.fn().mockReturnValue(true),
+         off: vi.fn(),
+         on: vi.fn((event: string, listener: () => void) => {
+            listeners[event] = listener;
+         }),
+         pause: vi.fn(),
+         play: vi.fn(),
+         ready: vi.fn((callback: () => void) => {
+            callback();
+         }),
+         remotePlayback: vi.fn(() => { return plugin; }),
+         trigger: vi.fn((event: string) => {
+            listeners[event]?.();
+         }),
+         usingPlugin: vi.fn().mockReturnValue(true),
+      } as unknown as VideoJsPlayer;
+
+      plugin = new RemotePlaybackPlugin(player, { addButtonToControlBar: false });
+
+      expect(player.on).toHaveBeenCalledWith(EVENTS.PROMPT_REQUESTED, expect.any(Function));
+      expect(plugin.strategy).toBeDefined();
+      if (!plugin.strategy) {
+         throw new Error('Expected strategy to be defined');
+      }
+
+      const promptSpy = vi.spyOn(plugin.strategy, 'prompt').mockResolvedValue(undefined),
+            button = new BaseButton(player);
+
+      button.handleClick();
+
+      expect(player.trigger).toHaveBeenCalledWith(EVENTS.PROMPT_REQUESTED);
+      expect(promptSpy).toHaveBeenCalledTimes(1);
+
+      await Promise.resolve();
    });
 });

--- a/tests/mocks/video-js-mock.ts
+++ b/tests/mocks/video-js-mock.ts
@@ -1,5 +1,6 @@
 import { vi } from 'vitest';
 import type { VideoJs } from '../../@types/videojs';
+import type { VideoJsPlayer } from '../../@types/videojs';
 
 export class MockButton {
    // These properties are used by the tests to verify that the button
@@ -7,13 +8,19 @@ export class MockButton {
    public _controlText = '';
    public _superDisposed = false;
    private _el: HTMLButtonElement;
+   private _player: VideoJsPlayer;
 
-   public constructor() {
+   public constructor(player: VideoJsPlayer) {
+      this._player = player;
       this._el = document.createElement('button');
    }
 
    public el(): HTMLButtonElement {
       return this._el;
+   }
+
+   public player(): VideoJsPlayer {
+      return this._player;
    }
 
    public addClass(className: string): void {
@@ -32,6 +39,10 @@ export class MockButton {
       this._el.classList.add('vjs-hidden');
    }
 
+   public localize(text: string): string {
+      return text;
+   }
+
    public controlText(text: string): void {
       this._controlText = text;
    }
@@ -48,10 +59,16 @@ export class MockButton {
 vi.mock('@silvermine/video.js', () => {
    class MockPlugin {
       public readonly log: ReturnType<typeof vi.fn> & { error: ReturnType<typeof vi.fn> };
+      public readonly player: VideoJsPlayer;
 
-      public constructor() {
+      public constructor(player: VideoJsPlayer) {
          this.log = vi.fn() as MockPlugin['log'];
          this.log.error = vi.fn();
+         this.player = player;
+      }
+
+      public dispose(): void {
+         return;
       }
    }
 
@@ -76,6 +93,7 @@ vi.mock('@silvermine/video.js', () => {
          VERSION: 'test-videojs-version',
          log: vi.fn(),
          registerPlugin: vi.fn(),
+         registerComponent: vi.fn(),
          getPlugin,
          getComponent,
       } as unknown as VideoJs,

--- a/tests/strategies.test.ts
+++ b/tests/strategies.test.ts
@@ -2,9 +2,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import './mocks/video-js-mock';
 import type { VideoJsPlayer } from '../@types/videojs';
 import type { RemotePlaybackStrategy } from '../src/js/RemotePlaybackPlugin';
+import EVENTS from '../src/js/constants/events';
 import { AirPlayManager } from '../src/js/strategies/AirPlayManager';
 import { RemotePlaybackManager } from '../src/js/strategies/RemotePlaybackManager';
 import { checkClientSupport, checkClientSupportWithAirPlay } from '../src/js/lib/check-client-support';
+import { BaseButton } from '../src/js/buttons/BaseButton';
 
 vi.mock('../src/js/lib/check-client-support', () => {
    return {
@@ -184,13 +186,14 @@ describe.each(STRATEGIES)('$name', (strategy) => {
    });
 
    it('creates a button that delegates clicks to prompt', () => {
-      const promptSpy = vi.spyOn(manager, 'prompt').mockResolvedValue(undefined),
-            button = manager.makeButton({});
+      const triggerSpy = vi.spyOn(context.player, 'trigger'),
+            button = new BaseButton(context.player);
 
       expect(button).toBeDefined();
       expect(button?.buildCSSClass()).toContain('vjs-remoteplayback-button');
-      button?.handleClick({} as any);
-      expect(promptSpy).toHaveBeenCalledTimes(1);
+      button?.handleClick();
+      expect(triggerSpy).toHaveBeenCalledTimes(1);
+      expect(triggerSpy).toHaveBeenCalledWith(EVENTS.PROMPT_REQUESTED);
    });
 
    it('prompts using the strategy-specific browser API', async () => {


### PR DESCRIPTION
The goal of this PR is to fix it to properly register the button with Video.js, rather than using a custom factory function for the button, and to handle various refactors to better align it with Video.js methodologies.

## Major Adjustments

- Adjust the plugin to register one component `remotePlaybackButton`, which will render as an AirPlay or Casting button depending on whether AirPlay is detected by the client. c2f61c5a8928a68983331fa301cd0e4cea867dcf
- Improve the buttons to use the standard Button constructor. f5a25ccf0e7e0cd9d00be339ef207e2140035bcb
  - In doing so, we must change the way the button behaves. The standard constructor only passes in the player, not our manager. Since the button no longer has a reference to the manager, it can't call the manager's `prompt` method when the button is clicked. So, we update the button to just send a `PROMPT_REQUESTED` event, and the plugin receives that event and asks the manager to run the `prompt` method.
- Improve the plugin to use some standard Video.js methods and properties that it wasn't using, namely:
  - Improve the `isPlayerWithRemotePlaybackPlugin` plugin type guard to use `hasPlugin`. 76a263aa0fee0f9f0cc159a9d2f2651038bc7af7
  - Improve plugin to use the built-in `this.player` property. 7273a4ee0206a43f52c9493d023d195224d70723
  - Improve the button to use the built-in `this.player()` method. 60f47dc6e1ab42c13875941fd2afc28e5e455994

## Additional Improvements

- Eliminate class properties that aren't necessary because they're not reused throughout the class. 73346c8f88ab9ad5e43ef9da9cbe97addc5ccba1 6bb0198a00fc1aa6f74333e13bf252cc8c76e6e1
- Add an `addButtonToControlBar` option so that clients can opt to NOT add the button to the Video.js control bar, if they have custom button setup. b548ae490007abe5c65303a1b338f6bad8669446
- Support localization of the button label. 669b5ce00c75a3f0a95c649e2d8cdb59ad635a89
- Adjust tests and documentation for all these changes.
